### PR TITLE
Set example params in change nodes

### DIFF
--- a/examples/basic-get-cert-first-ref-example.json
+++ b/examples/basic-get-cert-first-ref-example.json
@@ -1,79 +1,79 @@
 [
     {
-        "id": "52082b1f.b6e884",
+        "id": "57bd456f.096b3c",
         "type": "tab",
         "label": "TIE Get Certificate First References Example",
         "disabled": false,
-        "info": "This sample invokes the TIE DXL service to retrieve the set of systems which\r\nhave referenced a certificate (as identified by hashes). The response to the\r\nTIE request is printed to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n\r\n### Setup\r\n\r\n* Edit the `Specify cert hashes` node and modify the `Payload` property with the\r\n  hash of the certificate (and, optionally, the associated public key) that you\r\n  want to use for the lookup.\r\n\r\n  For example, if the SHA-1 of the certificate body is\r\n  \"6eae26db8c13182a7947982991b4321732cc3de2\" and the SHA-1 of the associated\r\n  public key is \"3b87a2d6f39770160364b79a152fcc73bae27adf\", you could enter\r\n  the following JSON-formatted document:\r\n  \r\n  ```json \r\n  {\r\n    \"certBodySha1\": \"6eae26db8c13182a7947982991b4321732cc3de2\",\r\n    \"publicKeySha1\": \"3b87a2d6f39770160364b79a152fcc73bae27adf\"\r\n  }\r\n  ```\r\n\r\n  If you only have a SHA-1 for the certificate body but not a SHA-1 for the\r\n  associated public key, you could instead enter the following:\r\n\r\n  ```json \r\n  {\r\n    \"certBodySha1\": \"6eae26db8c13182a7947982991b4321732cc3de2\",\r\n  }\r\n  ```\r\n    \r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the\r\n  `Get first references from TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify cert hashes` node.\r\n\r\n### Output\r\n\r\nThe output in the Node-RED `debug` tab should appear similar to the following:\r\n\r\n```\r\n▶ [ object, object]\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ array[2]\r\n ▼ 0: object\r\n     date: 1475873692\r\n     agentGuid: \"{3a6f574a-3e6f-436d-acd4-bcde336b054d}\"\r\n ▼ 1: object\r\n     date: 1478626172\r\n     agentGuid: \"{68125cd6-a5d8-11e6-348e-000c29663178}\"\r\n```\r\n\r\nEach entry in the array is an object containing details about a system that has\r\nreferenced the certificate. The following information is included in each\r\nentry:\r\n\r\n* GUID of the system that referenced the certificate\r\n* Time the system first referenced the certificate\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Specify cert hashes\r\n\r\nThis is an `inject` input node which starts the flow. This node\r\ninjects a new message with a `payload` property which specifies the hash of the\r\ncertificate (and, optionally, the associated public key) to use for the lookup.\r\n\r\n#### Set hash request parameters\r\n\r\nThis is a `change` node which copies the value from the `payload.certBodySha1`\r\nmessage property to the `sha1` property and the value from the\r\n`payload.publicKeySha1` message property to the `publicKeySha1` property.\r\nThe `Get first references from TIE` node uses the `sha1` and `publicKeySha1`\r\nproperties when constructing the parameters for the TIE first references\r\nrequest. \r\n\r\n#### Get first references from TIE\r\n\r\nThis is a `tie get certificate first references` node. This node connects to\r\nthe DXL fabric and sends a DXL `Request` message to the TIE service to lookup\r\nfirst references information.\r\n\r\nThe request message also includes the `sha1` and `publicKeySha1` properties set\r\nby the `Set hash request parameters` node.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" to indicate that the\r\npayload for the response should be added to the output message as a JavaScript\r\nobject decoded from JSON.\r\n\r\n#### Output first references\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Get first references from TIE` node. The output should\r\ninclude information for the systems that have referenced the certificate."
+        "info": "This sample invokes the TIE DXL service to retrieve the set of systems which\r\nhave referenced a certificate (as identified by hashes). The response to the\r\nTIE request is printed to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see the\r\n  [DXL Configuration Sample](https://github.com/opendxl/node-red-contrib-dxl/wiki/Client-Configuration)).\r\n* A TIE service is available on the DXL fabric.\r\n\r\n### Setup\r\n\r\n* Edit the `Specify hash request parameters` node and modify the `msg.sha1`\r\n  rule with the hash of the certificate and the `msg.publicKeySha1` rule with\r\n  the hash of the public key that you want to use for the lookup. Note that\r\n  the `msg.publicKeySha1` property is optional so this value can be set to an\r\n  empty string or the property may be removed entirely if the public key is\r\n  not known.\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the\r\n  `Get first references from TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Start flow` node.\r\n\r\n### Output\r\n\r\nThe output in the Node-RED `debug` tab should appear similar to the following:\r\n\r\n```\r\n▶ [ object, object]\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ array[2]\r\n ▼ 0: object\r\n     date: 1475873692\r\n     agentGuid: \"{3a6f574a-3e6f-436d-acd4-bcde336b054d}\"\r\n ▼ 1: object\r\n     date: 1478626172\r\n     agentGuid: \"{68125cd6-a5d8-11e6-348e-000c29663178}\"\r\n```\r\n\r\nEach entry in the array is an object containing details about a system that has\r\nreferenced the certificate. The following information is included in each\r\nentry:\r\n\r\n* GUID of the system that referenced the certificate\r\n* Time the system first referenced the certificate\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start flow\r\n\r\nThis is an `inject` input node which starts a new flow.\r\n\r\n#### Set hash request parameters\r\n\r\nThis is a `change` node which sets the hash of the certificate to the\r\n`msg.sha1` property and the hash of the associated public key to the\r\n`msg.publicKeySha1` property. The `Get first references from TIE` node uses the\r\n`sha1` and `publicKeySha1` properties when constructing the parameters for the\r\nTIE first references request. \r\n\r\n#### Get first references from TIE\r\n\r\nThis is a `tie get certificate first references` node. This node connects to\r\nthe DXL fabric and sends a DXL `Request` message to the TIE service to lookup\r\nfirst references information.\r\n\r\nThe request message also includes the `sha1` and `publicKeySha1` properties set\r\nby the `Set hash request parameters` node.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" to indicate that the\r\npayload for the response should be added to the output message as a JavaScript\r\nobject decoded from JSON.\r\n\r\n#### Output first references\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Get first references from TIE` node. The output should\r\ninclude information for the systems that have referenced the certificate."
     },
     {
-        "id": "e9d8da4e.da51e8",
+        "id": "fb15ff78.6b209",
         "type": "dxl-tie-get-certificate-first-references",
-        "z": "52082b1f.b6e884",
+        "z": "57bd456f.096b3c",
         "name": "Get first references from TIE",
         "client": "",
         "returnType": "obj",
-        "x": 320,
-        "y": 220,
+        "x": 340,
+        "y": 200,
         "wires": [
             [
-                "ea3234fc.2618a8"
+                "d8bf3597.02c458"
             ]
         ]
     },
     {
-        "id": "5b6fae81.69618",
+        "id": "9f0ad1f8.a4518",
         "type": "inject",
-        "z": "52082b1f.b6e884",
-        "name": "Specify cert hashes",
+        "z": "57bd456f.096b3c",
+        "name": "Start flow",
         "topic": "",
-        "payload": "{\"certBodySha1\":\"6eae26db8c13182a7947982991b4321732cc3de2\",\"publicKeySha1\":\"3b87a2d6f39770160364b79a152fcc73bae27adf\"}",
-        "payloadType": "json",
+        "payload": "",
+        "payloadType": "str",
         "repeat": "",
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 130,
+        "x": 100,
         "y": 40,
         "wires": [
             [
-                "16c4b516.67491b"
+                "d8c84b39.16fe78"
             ]
         ]
     },
     {
-        "id": "ea3234fc.2618a8",
+        "id": "d8bf3597.02c458",
         "type": "debug",
-        "z": "52082b1f.b6e884",
+        "z": "57bd456f.096b3c",
         "name": "Output first references",
         "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
         "complete": "payload",
-        "x": 560,
-        "y": 220,
+        "x": 600,
+        "y": 200,
         "wires": []
     },
     {
-        "id": "16c4b516.67491b",
+        "id": "d8c84b39.16fe78",
         "type": "change",
-        "z": "52082b1f.b6e884",
+        "z": "57bd456f.096b3c",
         "name": "Set hash request parameters",
         "rules": [
             {
                 "t": "set",
                 "p": "sha1",
                 "pt": "msg",
-                "to": "payload.certBodySha1",
-                "tot": "msg"
+                "to": "6eae26db8c13182a7947982991b4321732cc3de2",
+                "tot": "str"
             },
             {
                 "t": "set",
                 "p": "publicKeySha1",
                 "pt": "msg",
-                "to": "payload.publicKeySha1",
-                "tot": "msg"
+                "to": "3b87a2d6f39770160364b79a152fcc73bae27adf",
+                "tot": "str"
             }
         ],
         "action": "",
@@ -85,18 +85,18 @@
         "y": 120,
         "wires": [
             [
-                "e9d8da4e.da51e8"
+                "fb15ff78.6b209"
             ]
         ]
     },
     {
-        "id": "4eda9d46.1590a4",
+        "id": "68630488.c6f59c",
         "type": "comment",
-        "z": "52082b1f.b6e884",
-        "name": "Supply the cert hashes in the 'Specify cert hashes' node",
+        "z": "57bd456f.096b3c",
+        "name": "Supply the cert hashes in the 'Specify hash request parameters' node",
         "info": "",
         "x": 460,
-        "y": 40,
+        "y": 60,
         "wires": []
     }
 ]

--- a/examples/basic-get-cert-reputation-example.json
+++ b/examples/basic-get-cert-reputation-example.json
@@ -1,15 +1,15 @@
 [
     {
-        "id": "8084b4ef.d5b8c8",
+        "id": "7dc0eb0c.a9d3d4",
         "type": "tab",
         "label": "TIE Get Certificate Reputation Example",
         "disabled": false,
-        "info": "This sample invokes the TIE DXL service to retrieve the reputation of a\r\ncertificate (as identified by hashes). The response to the TIE request is\r\nprinted to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n\r\n### Setup\r\n\r\n* Edit the `Specify cert hashes` node and modify the `Payload` property with the\r\n  hash of the certificate (and, optionally, the associated public key) that you\r\n  want to use for the lookup.\r\n\r\n  For example, if the SHA-1 of the certificate body is\r\n  \"6eae26db8c13182a7947982991b4321732cc3de2\" and the SHA-1 of the associated\r\n  public key is \"3b87a2d6f39770160364b79a152fcc73bae27adf\", you could enter\r\n  the following JSON-formatted document:\r\n  \r\n  ```json \r\n  {\r\n    \"certBodySha1\": \"6eae26db8c13182a7947982991b4321732cc3de2\",\r\n    \"publicKeySha1\": \"3b87a2d6f39770160364b79a152fcc73bae27adf\"\r\n  }\r\n  ```\r\n\r\n  If you only have a SHA-1 for the certificate body but not a SHA-1 for the\r\n  associated public key, you could instead enter the following:\r\n\r\n  ```json \r\n  {\r\n    \"certBodySha1\": \"6eae26db8c13182a7947982991b4321732cc3de2\",\r\n  }\r\n  ```\r\n    \r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the\r\n  `Get reputation from TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify cert hashes` node.\r\n\r\n### Output\r\n\r\nThe output in the Node-RED `debug` tab should appear similar to the following:\r\n\r\n```\r\n▶ { 2: object, 4: object }\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ object\r\n ▼ 2: object\r\n  ▼ attributes: object\r\n      2108821: \"94\"\r\n      2109077: \"1454912619\"\r\n      2117524: \"0\"\r\n      2120596: \"0\"\r\n    createDate: 1476318514\r\n    providerId: 2\r\n    trustLevel: 99\r\n ▼ 4: object\r\n  ▼ attributes: object\r\n      2109333: \"12\"\r\n      2109589: \"1476318514\"\r\n      2139285: \"7318349394477075\r\n    createDate: 1476318514\r\n    providerId: 4\r\n    trustLevel: 0\r\n```\r\n\r\nThe `key` for each entry in the object corresponds to a particular `provider` of\r\nthe associated `reputation`. The list of certificate reputation providers can\r\nbe found in the\r\n[CertProvider documentation](https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertProvider)\r\nin the TIE Python client SDK.\r\n\r\nThe McAfee Global Threat Intelligence (GTI) service is identified in the results\r\nas `providerId: 2`. The trust level associated with the GTI response\r\n(`trustLevel: 99`) indicates that the certificate is known good.\r\n\r\nSee the \r\n[TrustLevel documentation](https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.TrustLevel)\r\nin the TIE Python client SDK for the list of standard trust levels.\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Specify cert hashes\r\n\r\nThis is an `inject` input node which starts the flow. This node\r\ninjects a new message with a `payload` property which specifies the hash of the\r\ncertificate (and, optionally, the associated public key) to use for the lookup.\r\n\r\n#### Set hash request parameters\r\n\r\nThis is a `change` node which copies the value from the `payload.certBodySha1`\r\nmessage property to the `sha1` property and the value from the\r\n`payload.publicKeySha1` message property to the `publicKeySha1` property.\r\nThe `Get reputation from TIE` node uses the `sha1` and `publicKeySha1`\r\nproperties when constructing the parameters for the TIE certificate reputation\r\nrequest. \r\n\r\n#### Get reputation from TIE\r\n\r\nThis is a `tie get certificate reputation` node. This node connects to\r\nthe DXL fabric and sends a DXL `Request` message to the TIE service to lookup\r\ncertificate reputation information.\r\n\r\nThe request message also includes the `sha1` and `publicKeySha1` properties set\r\nby the `Set hash request parameters` node.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" to indicate that the\r\npayload for the response should be added to the output message as a JavaScript\r\nobject decoded from JSON.\r\n\r\n#### Output first references\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Get reputation from TIE` node. The output should\r\ninclude information for reputation data for the certificate."
+        "info": "This sample invokes the TIE DXL service to retrieve the reputation of a\r\ncertificate (as identified by hashes). The response to the TIE request is\r\nprinted to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n\r\n### Setup\r\n\r\n* Edit the `Specify hash request parameters` node and modify the `msg.sha1`\r\n  rule with the hash of the certificate and the `msg.publicKeySha1` rule with\r\n  the hash of the public key that you want to use for the lookup. Note that\r\n  the `msg.publicKeySha1` property is optional so this value can be set to an\r\n  empty string or the property may be removed entirely if the public key is\r\n  not known.\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the\r\n  `Get reputation from TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the \r\n`Start flow` node.\r\n\r\n### Output\r\n\r\nThe output in the Node-RED `debug` tab should appear similar to the following:\r\n\r\n```\r\n▶ { 2: object, 4: object }\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ object\r\n ▼ 2: object\r\n  ▼ attributes: object\r\n      2108821: \"94\"\r\n      2109077: \"1454912619\"\r\n      2117524: \"0\"\r\n      2120596: \"0\"\r\n    createDate: 1476318514\r\n    providerId: 2\r\n    trustLevel: 99\r\n ▼ 4: object\r\n  ▼ attributes: object\r\n      2109333: \"12\"\r\n      2109589: \"1476318514\"\r\n      2139285: \"7318349394477075\r\n    createDate: 1476318514\r\n    providerId: 4\r\n    trustLevel: 0\r\n```\r\n\r\nThe `key` for each entry in the object corresponds to a particular `provider` of\r\nthe associated `reputation`. The list of certificate reputation providers can\r\nbe found in the\r\n[CertProvider documentation](https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertProvider.html)\r\nin the TIE JavaScript client SDK.\r\n\r\nThe McAfee Global Threat Intelligence (GTI) service is identified in the results\r\nas `providerId: 2`. The trust level associated with the GTI response\r\n(`trustLevel: 99`) indicates that the certificate is known good.\r\n\r\nSee the \r\n[TrustLevel documentation](https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-TrustLevel.html)\r\nin the TIE JavaScript client SDK for the list of standard trust levels.\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start flow\r\n\r\nThis is an `inject` input node which starts the flow.\r\n\r\n#### Set hash request parameters\r\n\r\nThis is a `change` node which sets the hash of the certificate to the\r\n`msg.sha1` property and the hash of the associated public key to the\r\n`msg.publicKeySha1` property. The `Get reputation from TIE` node uses the\r\n`sha1` and `publicKeySha1` properties when constructing the parameters for the\r\nTIE first references request. \r\n\r\n#### Get reputation from TIE\r\n\r\nThis is a `tie get certificate reputation` node. This node connects to\r\nthe DXL fabric and sends a DXL `Request` message to the TIE service to lookup\r\ncertificate reputation information.\r\n\r\nThe request message also includes the `sha1` and `publicKeySha1` properties set\r\nby the `Set hash request parameters` node.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" to indicate that the\r\npayload for the response should be added to the output message as a JavaScript\r\nobject decoded from JSON.\r\n\r\n#### Output first references\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Get reputation from TIE` node. The output should\r\ninclude information for reputation data for the certificate."
     },
     {
-        "id": "e29d673a.e54ae8",
+        "id": "82d5752e.002908",
         "type": "dxl-tie-get-certificate-reputation",
-        "z": "8084b4ef.d5b8c8",
+        "z": "7dc0eb0c.a9d3d4",
         "name": "Get reputation from TIE",
         "client": "",
         "returnType": "obj",
@@ -17,63 +17,63 @@
         "y": 200,
         "wires": [
             [
-                "4a548230.ab749c"
+                "cf4f3478.78da28"
             ]
         ]
     },
     {
-        "id": "4a548230.ab749c",
+        "id": "cf4f3478.78da28",
         "type": "debug",
-        "z": "8084b4ef.d5b8c8",
+        "z": "7dc0eb0c.a9d3d4",
         "name": "Output reputation",
         "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
         "complete": "payload",
-        "x": 550,
+        "x": 570,
         "y": 200,
         "wires": []
     },
     {
-        "id": "e7edb704.5933b8",
+        "id": "cb79cb07.653e38",
         "type": "inject",
-        "z": "8084b4ef.d5b8c8",
-        "name": "Specify cert hashes",
+        "z": "7dc0eb0c.a9d3d4",
+        "name": "Start flow",
         "topic": "",
-        "payload": "{\"certBodySha1\":\"6eae26db8c13182a7947982991b4321732cc3de2\",\"publicKeySha1\":\"3b87a2d6f39770160364b79a152fcc73bae27adf\"}",
-        "payloadType": "json",
+        "payload": "",
+        "payloadType": "str",
         "repeat": "",
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 130,
+        "x": 100,
         "y": 40,
         "wires": [
             [
-                "13cf8cf4.79e563"
+                "8d82df6.018e92"
             ]
         ]
     },
     {
-        "id": "13cf8cf4.79e563",
+        "id": "8d82df6.018e92",
         "type": "change",
-        "z": "8084b4ef.d5b8c8",
+        "z": "7dc0eb0c.a9d3d4",
         "name": "Set hash request parameters",
         "rules": [
             {
                 "t": "set",
                 "p": "sha1",
                 "pt": "msg",
-                "to": "payload.certBodySha1",
-                "tot": "msg"
+                "to": "6eae26db8c13182a7947982991b4321732cc3de2",
+                "tot": "str"
             },
             {
                 "t": "set",
                 "p": "publicKeySha1",
                 "pt": "msg",
-                "to": "payload.publicKeySha1",
-                "tot": "msg"
+                "to": "3b87a2d6f39770160364b79a152fcc73bae27adf",
+                "tot": "str"
             }
         ],
         "action": "",
@@ -85,18 +85,18 @@
         "y": 120,
         "wires": [
             [
-                "e29d673a.e54ae8"
+                "82d5752e.002908"
             ]
         ]
     },
     {
-        "id": "3c438871.c71258",
+        "id": "ec6fdea5.bd3df",
         "type": "comment",
-        "z": "8084b4ef.d5b8c8",
-        "name": "Supply the cert hashes in the 'Specify cert hashes' node",
+        "z": "7dc0eb0c.a9d3d4",
+        "name": "Supply the cert hashes in the 'Specify hash request parameters' node",
         "info": "",
         "x": 460,
-        "y": 40,
+        "y": 60,
         "wires": []
     }
 ]

--- a/examples/basic-get-file-first-ref-example.json
+++ b/examples/basic-get-file-first-ref-example.json
@@ -1,64 +1,64 @@
 [
     {
-        "id": "ca491f04.1ee0d",
+        "id": "a90d6ed3.c46fb",
         "type": "tab",
         "label": "TIE Get File First References Example",
         "disabled": false,
-        "info": "This sample invokes the TIE DXL service to retrieve the set of systems which\r\nhave referenced a file (as identified by hashes). The response to the TIE\r\nrequest is printed to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n\r\n### Setup\r\n\r\nEdit the `Specify file hashes` node and modify the `Payload` property with the\r\nhashes of the file that you want to use for the lookup.\r\n\r\nThe default hashes used in the JSON-formatted document for this node\r\npertain to `notepad.exe`:\r\n\r\n```json\r\n{\r\n  \"md5\": \"f2c7bb8acc97f92e987a2d4087d021b1\",\r\n  \"sha1\": \"7eb0139d2175739b3ccb0d1110067820be6abd29\",\r\n  \"sha256\": \"142e1d688ef0568370c37187fd9f2351d7ddeda574f8bfa9b0fa4ef42db85aa2\"\r\n}\r\n```\r\n\r\nThis sample is equivalent to running the `\"Where Has File Run\"` action in the\r\n`\"TIE Reputations\"` page within ePO.\r\n\r\nA simple way to determine a valid set of hashes to use with this sample is\r\ndetailed below:\r\n\r\n* Open ePO and navigate to the `\"TIE Reputations\"` page.\r\n* Select the `\"File Search\"` tab\r\n* Select a `file` in the list\r\n* Click the `\"Actions\"` button at the bottom left and select\r\n`\"Where Has File Run\"`\r\n* The `\"Where Has File Run\"` results page is displayed. The GUIDs associated\r\nwith the systems in this list are what will be displayed when the sample is\r\nexecuted.\r\n* Close the `\"Where Has File Run\"` results\r\n* Click on the same `file` to display its associated reputation information\r\n* In the `\"File Reputations Information\"` page copy the `\"MD5 Hash\"`,\r\n`\"SHA-1 Hash\"`, and `\"SHA-256 Hash\"` values and paste them into the sample\r\nprior to running (as shown in the example above)\r\n\r\nTo deploy the flow, press the `Deploy` button in the upper-right corner of the\r\nscreen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\nwith the word `connected` should appear under the\r\n`Get first references from TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify file hashes` node.\r\n\r\n### Output\r\n\r\nThe output in the Node-RED `debug` tab should appear similar to the following:\r\n\r\n```\r\n▶ [ object, object, object ]\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ array[2]\r\n ▼ 0: object\r\n     date: 1475873692\r\n     agentGuid: \"{3a6f574a-3e6f-436d-acd4-bcde336b054d}\"\r\n ▼ 1: object\r\n     date: 1476316674\r\n     agentGuid: \"{d48d3d1a-915e-11e6-323a-000c2992f5d9}\"\r\n ▼ 2: object\r\n     date: 1478626172\r\n     agentGuid: \"{68125cd6-a5d8-11e6-348e-000c29663178}\"\r\n```\r\n\r\nEach entry in the array is an object containing details about a system that has\r\nreferenced the file. The following information is included in each entry:\r\n\r\n* GUID of the system that referenced the file\r\n* Time the system first referenced the file\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Specify file hashes\r\n\r\nThis is an `inject` input node which starts the flow. This node\r\ninjects a new message with a `payload` property which specifies the hashes of\r\nthe file to use for the lookup.\r\n\r\n#### Set hash request parameters\r\n\r\nThis is a `change` node which copies the value from the `payload` message\r\nproperty to the `hashes` property. The `Get first references from TIE` node uses\r\nthe `hashes` property when constructing the parameters for the TIE first\r\nreferences request. \r\n\r\n#### Get first references from TIE\r\n\r\nThis is a `tie get file first references` node. This node connects to the DXL\r\nfabric and sends a DXL `Request` message to the TIE service to lookup\r\nfirst references information.\r\n\r\nThe request message includes the `hashes` properties set by the\r\n`Set hash request parameters` node.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" to indicate that the\r\npayload for the response should be added to the output message as a JavaScript\r\nobject decoded from JSON.\r\n\r\n#### Output first references\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Get first references from TIE` node. The output should\r\ninclude information for the systems that have referenced the file."
+        "info": "This sample invokes the TIE DXL service to retrieve the set of systems which\r\nhave referenced a file (as identified by hashes). The response to the TIE\r\nrequest is printed to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n\r\n### Setup\r\n\r\nEdit the `Specify hash request parameters` node and modify the `msg.md5`,\r\n`msg.sha1`, and `msg.sha256` rules with the hashes of the file to be looked up.\r\n\r\nThe default hashes used in the JSON-formatted document for this node\r\npertain to `notepad.exe`:\r\n\r\n```json\r\n{\r\n  \"md5\": \"f2c7bb8acc97f92e987a2d4087d021b1\",\r\n  \"sha1\": \"7eb0139d2175739b3ccb0d1110067820be6abd29\",\r\n  \"sha256\": \"142e1d688ef0568370c37187fd9f2351d7ddeda574f8bfa9b0fa4ef42db85aa2\"\r\n}\r\n```\r\n\r\nThis sample is equivalent to running the `\"Where Has File Run\"` action in the\r\n`\"TIE Reputations\"` page within ePO.\r\n\r\nA simple way to determine a valid set of hashes to use with this sample is\r\ndetailed below:\r\n\r\n* Open ePO and navigate to the `\"TIE Reputations\"` page.\r\n* Select the `\"File Search\"` tab\r\n* Select a `file` in the list\r\n* Click the `\"Actions\"` button at the bottom left and select\r\n`\"Where Has File Run\"`\r\n* The `\"Where Has File Run\"` results page is displayed. The GUIDs associated\r\n  with the systems in this list are what will be displayed when the sample is\r\n  executed.\r\n* Close the `\"Where Has File Run\"` results\r\n* Click on the same `file` to display its associated reputation information\r\n* In the `\"File Reputations Information\"` page copy the `\"MD5 Hash\"`,\r\n  `\"SHA-1 Hash\"`, and `\"SHA-256 Hash\"` values and paste them into the sample\r\n  prior to running (as shown in the example above).\r\n\r\nTo deploy the flow, press the `Deploy` button in the upper-right corner of the\r\nscreen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\nwith the word `connected` should appear under the\r\n`Get first references from TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify file hashes` node.\r\n\r\n### Output\r\n\r\nThe output in the Node-RED `debug` tab should appear similar to the following:\r\n\r\n```\r\n▶ [ object, object, object ]\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ array[2]\r\n ▼ 0: object\r\n     date: 1475873692\r\n     agentGuid: \"{3a6f574a-3e6f-436d-acd4-bcde336b054d}\"\r\n ▼ 1: object\r\n     date: 1476316674\r\n     agentGuid: \"{d48d3d1a-915e-11e6-323a-000c2992f5d9}\"\r\n ▼ 2: object\r\n     date: 1478626172\r\n     agentGuid: \"{68125cd6-a5d8-11e6-348e-000c29663178}\"\r\n```\r\n\r\nEach entry in the array is an object containing details about a system that has\r\nreferenced the file. The following information is included in each entry:\r\n\r\n* GUID of the system that referenced the file\r\n* Time the system first referenced the file\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start flow\r\n\r\nThis is an `inject` input node which starts the flow.\r\n\r\n#### Set hash request parameters\r\n\r\nThis is a `change` node which sets values for different hash types &mdash;\r\n`md5`, `sha1`, and `sha256` &mdash; onto an object which is stored to the\r\n`hashes` property on the message. The `Get first references from TIE` node uses\r\nthe `hashes` property when constructing the parameters for the TIE first\r\nreferences request. \r\n\r\n#### Get first references from TIE\r\n\r\nThis is a `tie get file first references` node. This node connects to the DXL\r\nfabric and sends a DXL `Request` message to the TIE service to lookup\r\nfirst references information.\r\n\r\nThe request message includes the `hashes` property set by the\r\n`Set hash request parameters` node.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" to indicate that the\r\npayload for the response should be added to the output message as a JavaScript\r\nobject decoded from JSON.\r\n\r\n#### Output first references\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Get first references from TIE` node. The output should\r\ninclude information for the systems that have referenced the file."
     },
     {
-        "id": "bc4fdfa7.28b84",
+        "id": "a6e154a1.519eb8",
         "type": "dxl-tie-get-file-first-references",
-        "z": "ca491f04.1ee0d",
+        "z": "a90d6ed3.c46fb",
         "name": "Get first references from TIE",
         "client": "",
         "returnType": "obj",
-        "x": 300,
-        "y": 220,
+        "x": 340,
+        "y": 200,
         "wires": [
             [
-                "70fe2756.7329f8"
+                "e6a4c444.e6f058"
             ]
         ]
     },
     {
-        "id": "a13fb19b.da61c",
+        "id": "de35c1ba.64015",
         "type": "inject",
-        "z": "ca491f04.1ee0d",
-        "name": "Specify file hashes",
+        "z": "a90d6ed3.c46fb",
+        "name": "Start flow",
         "topic": "",
-        "payload": "{\"md5\":\"f2c7bb8acc97f92e987a2d4087d021b1\",\"sha1\":\"7eb0139d2175739b3ccb0d1110067820be6abd29\",\"sha256\":\"142e1d688ef0568370c37187fd9f2351d7ddeda574f8bfa9b0fa4ef42db85aa2\"}",
+        "payload": "{}",
         "payloadType": "json",
         "repeat": "",
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 130,
+        "x": 100,
         "y": 40,
         "wires": [
             [
-                "8ed81075.70d3b"
+                "9a1e48dc.b92ee8"
             ]
         ]
     },
     {
-        "id": "70fe2756.7329f8",
+        "id": "e6a4c444.e6f058",
         "type": "debug",
-        "z": "ca491f04.1ee0d",
+        "z": "a90d6ed3.c46fb",
         "name": "Output first references",
         "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
         "complete": "payload",
-        "x": 540,
-        "y": 220,
+        "x": 600,
+        "y": 200,
         "wires": []
     },
     {
-        "id": "8ed81075.70d3b",
+        "id": "9a1e48dc.b92ee8",
         "type": "change",
-        "z": "ca491f04.1ee0d",
+        "z": "a90d6ed3.c46fb",
         "name": "Set hashes request parameter",
         "rules": [
             {
@@ -67,6 +67,27 @@
                 "pt": "msg",
                 "to": "payload",
                 "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "hashes.md5",
+                "pt": "msg",
+                "to": "f2c7bb8acc97f92e987a2d4087d021b1",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "hashes.sha1",
+                "pt": "msg",
+                "to": "7eb0139d2175739b3ccb0d1110067820be6abd29",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "hashes.sha256",
+                "pt": "msg",
+                "to": "142e1d688ef0568370c37187fd9f2351d7ddeda574f8bfa9b0fa4ef42db85aa2",
+                "tot": "str"
             }
         ],
         "action": "",
@@ -74,22 +95,22 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 270,
+        "x": 250,
         "y": 120,
         "wires": [
             [
-                "bc4fdfa7.28b84"
+                "a6e154a1.519eb8"
             ]
         ]
     },
     {
-        "id": "1bb3c9fe.b8a3c6",
+        "id": "e77f5508.7c8508",
         "type": "comment",
-        "z": "ca491f04.1ee0d",
-        "name": "Supply the file hashes in the 'Specify file hashes' node",
+        "z": "a90d6ed3.c46fb",
+        "name": "Supply the file hashes in the 'Specify hash request parameter' node",
         "info": "",
         "x": 460,
-        "y": 40,
+        "y": 60,
         "wires": []
     }
 ]

--- a/examples/basic-get-file-reputation-example.json
+++ b/examples/basic-get-file-reputation-example.json
@@ -1,85 +1,45 @@
 [
     {
-        "id": "b1b630b3.6e4d7",
+        "id": "faa5c3ff.16484",
         "type": "tab",
         "label": "TIE Get File Reputation Example",
         "disabled": false,
-        "info": "This sample invokes the TIE DXL service to retrieve the reputation of a file (as\r\nidentified by hashes). The response to the TIE request is printed to the\r\nNode-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n\r\n### Setup\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Get reputation from TIE`\r\n  node.\r\n\r\n### Running\r\n\r\nTo exercise the flow for the \"notepad.exe\" file, double-click the button on the\r\nleft side of the `Specify hashes for Notepad.exe` node.\r\n\r\nTo exercise the flow for the \"EICAR Standard Anti-Virus Test File\" file,\r\ndouble-click the button on the left side of the `Specify hashes for EICAR` node.\r\n\r\n### Output\r\n\r\nThe output in the Node-RED `debug` tab after the flow is run for the\r\n`notepad.exe` file should appear similar to the following:\r\n\r\n```\r\n▶ { 1: object, 3: object }\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ object\r\n ▼ 1: object\r\n  ▼ attributes: object\r\n      2120340: \"2139160704\"\r\n    createDate: 1451502875\r\n    providerId: 1\r\n    trustLevel: 99\r\n ▼ 3: object\r\n  ▼ attributes: object\r\n      2101652: \"17\"\r\n      2102165: \"1451502875\"\r\n      2111893: \"21\"\r\n      2114965: \"0\"\r\n      2139285: \"72339069014638857\"\r\n    createDate: 1526675921\r\n    providerId: 3\r\n    trustLevel: 99\r\n```\r\n\r\nThe `key` for each entry in the object corresponds to a particular `provider` of\r\nthe associated `reputation`. The list of file reputation providers can\r\nbe found in the\r\n[FileProvider documentation](https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileProvider)\r\nin the TIE Python client SDK.\r\n\r\nThe McAfee Global Threat Intelligence (GTI) service is identified in the results\r\nas `providerId: 1`. The trust level associated with the GTI response\r\n(`trustLevel: 99`) indicates that the file is known good.\r\n\r\nThe output in the Node-RED `debug` tab after the flow is run for the `EICAR`\r\nfile should also appear similar to the following:\r\n\r\n```\r\n▶ { 1: object, 3: object }\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ object\r\n ▼ 1: object\r\n  ▼ attributes: object\r\n      2120340: \"2139162632\"\r\n    createDate: 1451504331\r\n    providerId: 1\r\n    trustLevel: 1\r\n ▼ 3: object\r\n  ▼ attributes: object\r\n      2101652: \"11\"\r\n      2102165: \"1451504331\"\r\n      2111893: \"22\"\r\n      2114965: \"0\"\r\n      2139285: \"72339069014638857\"\r\n    createDate: 1451504331\r\n    providerId: 3\r\n    trustLevel: 0\r\n```\r\n\r\nThe trust level associated with the GTI response (`trustLevel: 1`) indicates\r\nthat the file is known bad.\r\n\r\nSee the \r\n[TrustLevel documentation](https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.TrustLevel)\r\nin the TIE Python client SDK for the list of standard trust levels.\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Specify file hashes\r\n\r\nThis is an `inject` input node which starts the flow. This node\r\ninjects a new message with a `payload` property which specifies the hashes of\r\nthe file to use for the lookup.\r\n\r\n#### Set hashes request parameter\r\n\r\nThis is a `change` node which copies the value from the `payload` message\r\nproperty to the `hashes` property. The `Set hashes request parameter` node uses\r\nthe `hashes` property when constructing the parameters for the TIE reputation\r\nrequest. \r\n\r\n#### Get reputation from TIE\r\n\r\nThis is a `tie get file reputation` node. This node connects to\r\nthe DXL fabric and sends a DXL `Request` message to the TIE service to lookup\r\nfile reputation information.\r\n\r\nThe request message includes the `hashes` properties set by the\r\n`Set hashes request parameter` node.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" to indicate that the\r\npayload for the response should be added to the output message as a JavaScript\r\nobject decoded from JSON.\r\n\r\n#### Output reputation\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Get reputation from TIE` node. The output should\r\ninclude information for reputation data for the file."
+        "info": "This sample invokes the TIE DXL service to retrieve the reputation of a file (as\r\nidentified by hashes). The response to the TIE request is printed to the\r\nNode-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n\r\n### Setup\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the `Get reputation from TIE`\r\n  node.\r\n\r\n### Running\r\n\r\nTo exercise the flow for the \"notepad.exe\" file, double-click the button on the\r\nleft side of the `Start Notepad.exe lookup flow` node.\r\n\r\nTo exercise the flow for the \"EICAR Standard Anti-Virus Test File\" file,\r\ndouble-click the button on the left side of the `Start EICAR lookup flow` node.\r\n\r\n### Output\r\n\r\nThe output in the Node-RED `debug` tab after the flow is run for the\r\n`notepad.exe` file should appear similar to the following:\r\n\r\n```\r\n▶ { 1: object, 3: object }\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ object\r\n ▼ 1: object\r\n  ▼ attributes: object\r\n      2120340: \"2139160704\"\r\n    createDate: 1451502875\r\n    providerId: 1\r\n    trustLevel: 99\r\n ▼ 3: object\r\n  ▼ attributes: object\r\n      2101652: \"17\"\r\n      2102165: \"1451502875\"\r\n      2111893: \"21\"\r\n      2114965: \"0\"\r\n      2139285: \"72339069014638857\"\r\n    createDate: 1526675921\r\n    providerId: 3\r\n    trustLevel: 99\r\n```\r\n\r\nThe `key` for each entry in the object corresponds to a particular `provider` of\r\nthe associated `reputation`. The list of file reputation providers can\r\nbe found in the\r\n[FileProvider documentation](https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileProvider.html)\r\nin the TIE JavaScript client SDK.\r\n\r\nThe McAfee Global Threat Intelligence (GTI) service is identified in the results\r\nas `providerId: 1`. The trust level associated with the GTI response\r\n(`trustLevel: 99`) indicates that the file is known good.\r\n\r\nThe output in the Node-RED `debug` tab after the flow is run for the `EICAR`\r\nfile should also appear similar to the following:\r\n\r\n```\r\n▶ { 1: object, 3: object }\r\n```\r\n\r\nClick on the right arrow buttons to expand the contents of the object. The\r\ncontent should look similar to the following:\r\n\r\n```\r\n▼ object\r\n ▼ 1: object\r\n  ▼ attributes: object\r\n      2120340: \"2139162632\"\r\n    createDate: 1451504331\r\n    providerId: 1\r\n    trustLevel: 1\r\n ▼ 3: object\r\n  ▼ attributes: object\r\n      2101652: \"11\"\r\n      2102165: \"1451504331\"\r\n      2111893: \"22\"\r\n      2114965: \"0\"\r\n      2139285: \"72339069014638857\"\r\n    createDate: 1451504331\r\n    providerId: 3\r\n    trustLevel: 0\r\n```\r\n\r\nThe trust level associated with the GTI response (`trustLevel: 1`) indicates\r\nthat the file is known bad.\r\n\r\nSee the \r\n[TrustLevel documentation](https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-TrustLevel.html)\r\nin the TIE JavaScript client SDK for the list of standard trust levels.\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start lookup flow\r\n\r\nThese are `inject` input nodes which start the flow.\r\n\r\n#### Set hashes request parameter\r\n\r\nThese are `change` nodes which set values for different hash types &mdash;\r\n`md5`, `sha1`, and `sha256` &mdash; onto an object which is stored to the\r\n`hashes` property on the message. The `Get reputation from TIE` node uses\r\nthe `hashes` property when constructing the parameters for the TIE reputation\r\nrequest. \r\n\r\n#### Get reputation from TIE\r\n\r\nThis is a `tie get file reputation` node. This node connects to\r\nthe DXL fabric and sends a DXL `Request` message to the TIE service to lookup\r\nfile reputation information.\r\n\r\nThe request message includes the `hashes` properties set by the\r\n`Set hashes request parameter` nodes.\r\n\r\nThe `Return` property is set to \"a parsed JSON object\" to indicate that the\r\npayload for the response should be added to the output message as a JavaScript\r\nobject decoded from JSON.\r\n\r\n#### Output reputation\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Get reputation from TIE` node. The output should\r\ninclude information for reputation data for the file."
     },
     {
-        "id": "e678c6ec.e231c8",
+        "id": "545699af.427df8",
         "type": "dxl-tie-get-file-reputation",
-        "z": "b1b630b3.6e4d7",
+        "z": "faa5c3ff.16484",
         "name": "Get reputation from TIE",
         "client": "",
         "returnType": "obj",
-        "x": 290,
+        "x": 650,
         "y": 200,
         "wires": [
             [
-                "5393fe31.faf1b"
+                "c8a8e5c8.981828"
             ]
         ]
     },
     {
-        "id": "1f374194.839efe",
-        "type": "inject",
-        "z": "b1b630b3.6e4d7",
-        "name": "Specify hashes for Notepad.exe",
-        "topic": "",
-        "payload": "{\"md5\":\"f2c7bb8acc97f92e987a2d4087d021b1\",\"sha1\":\"7eb0139d2175739b3ccb0d1110067820be6abd29\",\"sha256\":\"142e1d688ef0568370c37187fd9f2351d7ddeda574f8bfa9b0fa4ef42db85aa2\"}",
-        "payloadType": "json",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "x": 170,
-        "y": 40,
-        "wires": [
-            [
-                "435743ea.02b88c"
-            ]
-        ]
-    },
-    {
-        "id": "5393fe31.faf1b",
+        "id": "c8a8e5c8.981828",
         "type": "debug",
-        "z": "b1b630b3.6e4d7",
+        "z": "faa5c3ff.16484",
         "name": "Output reputation",
         "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
         "complete": "payload",
-        "x": 510,
-        "y": 200,
+        "x": 630,
+        "y": 300,
         "wires": []
     },
     {
-        "id": "a462f316.d775d",
-        "type": "inject",
-        "z": "b1b630b3.6e4d7",
-        "name": "Specify hashes for EICAR",
-        "topic": "",
-        "payload": "{\"md5\":\"44d88612fea8a8f36de82e1278abb02f\",\"sha1\":\"3395856ce81f2b7382dee72602f798b642f14140\",\"sha256\":\"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\"}",
-        "payloadType": "json",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "x": 150,
-        "y": 100,
-        "wires": [
-            [
-                "435743ea.02b88c"
-            ]
-        ]
-    },
-    {
-        "id": "435743ea.02b88c",
+        "id": "12edccc3.9ed8e3",
         "type": "change",
-        "z": "b1b630b3.6e4d7",
-        "name": "Set hashes request parameter",
+        "z": "faa5c3ff.16484",
+        "name": "Set hashes request parameter for Notepad.exe",
         "rules": [
             {
                 "t": "set",
@@ -87,6 +47,27 @@
                 "pt": "msg",
                 "to": "payload",
                 "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "hashes.md5",
+                "pt": "msg",
+                "to": "f2c7bb8acc97f92e987a2d4087d021b1",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "hashes.sha1",
+                "pt": "msg",
+                "to": "7eb0139d2175739b3ccb0d1110067820be6abd29",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "hashes.sha256",
+                "pt": "msg",
+                "to": "142e1d688ef0568370c37187fd9f2351d7ddeda574f8bfa9b0fa4ef42db85aa2",
+                "tot": "str"
             }
         ],
         "action": "",
@@ -94,11 +75,99 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 470,
-        "y": 80,
+        "x": 300,
+        "y": 120,
         "wires": [
             [
-                "e678c6ec.e231c8"
+                "545699af.427df8"
+            ]
+        ]
+    },
+    {
+        "id": "7e4ef7d5.044008",
+        "type": "change",
+        "z": "faa5c3ff.16484",
+        "name": "Set hashes request parameter for EICAR",
+        "rules": [
+            {
+                "t": "set",
+                "p": "hashes",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "hashes.md5",
+                "pt": "msg",
+                "to": "44d88612fea8a8f36de82e1278abb02f",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "hashes.sha1",
+                "pt": "msg",
+                "to": "3395856ce81f2b7382dee72602f798b642f14140",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "hashes.sha256",
+                "pt": "msg",
+                "to": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 280,
+        "y": 300,
+        "wires": [
+            [
+                "545699af.427df8"
+            ]
+        ]
+    },
+    {
+        "id": "79eb30ab.b53de",
+        "type": "inject",
+        "z": "faa5c3ff.16484",
+        "name": "Start Notepad.exe lookup flow",
+        "topic": "",
+        "payload": "{}",
+        "payloadType": "json",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "x": 160,
+        "y": 40,
+        "wires": [
+            [
+                "12edccc3.9ed8e3"
+            ]
+        ]
+    },
+    {
+        "id": "9d4f41f0.3ab53",
+        "type": "inject",
+        "z": "faa5c3ff.16484",
+        "name": "Start EICAR lookup flow",
+        "topic": "",
+        "payload": "{}",
+        "payloadType": "json",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "x": 140,
+        "y": 200,
+        "wires": [
+            [
+                "7e4ef7d5.044008"
             ]
         ]
     }

--- a/examples/basic-set-cert-reputation-example.json
+++ b/examples/basic-set-cert-reputation-example.json
@@ -1,80 +1,94 @@
 [
     {
-        "id": "d25ff850.471288",
+        "id": "43588515.3b92dc",
         "type": "tab",
         "label": "TIE Set Certificate Reputation Example",
         "disabled": false,
-        "info": "This sample invokes the TIE DXL service to set the enterprise-specific\r\n`trust level` of a certificate (as identified by hashes). The response to the\r\nTIE request is printed to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n* The DXL client associated with the `Set reputation in TIE` node must have permission to send messages to\r\n  the `/mcafee/service/tie/cert/reputation/set` topic, which is part of the\r\n  `TIE Server Set Enterprise Reputation` authorization group.\r\n\r\n  The \r\n  [MAR client authorization documentation](https://opendxl.github.io/opendxl-client-python/pydoc/marsendauth.html)\r\n  provides an example of authorizing a DXL client to send messages to an\r\n  authorization group. While the example is based on McAfee Active Response\r\n  (MAR), the instructions are the same with the exception of swapping the\r\n  `TIE Server Set Enterprise Reputation` authorization group in place of\r\n  `Active Response Server API`.\r\n\r\n### Setup\r\n\r\n* Edit the `Specify cert hashes` node and modify the `Payload` property with the\r\n  hash of the certificate (and, optionally, the associated public key) that you\r\n  want to use for the set operation.\r\n\r\n  For example, if the SHA-1 of the certificate body is\r\n  \"6eae26db8c13182a7947982991b4321732cc3de2\" and the SHA-1 of the associated\r\n  public key is \"3b87a2d6f39770160364b79a152fcc73bae27adf\", you could enter\r\n  the following JSON-formatted document:\r\n  \r\n  ```json \r\n  {\r\n    \"certBodySha1\": \"6eae26db8c13182a7947982991b4321732cc3de2\",\r\n    \"publicKeySha1\": \"3b87a2d6f39770160364b79a152fcc73bae27adf\"\r\n  }\r\n  ```\r\n\r\n  If you only have a SHA-1 for the certificate body but not a SHA-1 for the\r\n  associated public key, you could instead enter the following:\r\n\r\n  ```json \r\n  {\r\n    \"certBodySha1\": \"6eae26db8c13182a7947982991b4321732cc3de2\",\r\n  }\r\n  ```\r\n    \r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the\r\n  `Set reputation in TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify cert hashes` node.\r\n\r\n### Output\r\n\r\nIf the set reputation operation succeeds, the following message will be\r\ndisplayed:\r\n\r\n```\r\nSucceeded\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Specify cert hashes\r\n\r\nThis is an `inject` input node which starts the flow. This node\r\ninjects a new message with a `payload` property which specifies the hash of the\r\ncertificate (and, optionally, the associated public key) to use for the set\r\noperation.\r\n\r\n#### Set hash request parameters\r\n\r\nThis is a `change` node which copies the value from the `payload.certBodySha1`\r\nmessage property to the `sha1` property and the value from the\r\n`payload.publicKeySha1` message property to the `publicKeySha1` property.\r\nThe `Set reputation in TIE` node uses the `sha1` and `publicKeySha1`\r\nproperties when constructing the parameters for the TIE certificate reputation\r\nrequest. \r\n\r\n#### Set reputation in TIE\r\n\r\nThis is a `tie set certificate reputation` node. This node connects to\r\nthe DXL fabric and sends a DXL `Request` message to the TIE service to set\r\ncertificate reputation information.\r\n\r\nThe request message includes the `sha1` and `publicKeySha1` properties set\r\nby the `Set hash request parameters` node.\r\n\r\nThe `Trust level` property is set to \"Known trusted\" and the\r\n`Comment` property is set to \"Reputation set via OpenDXL\". The `Comment`\r\nproperty can be empty but is useful in identifying the particular certificate\r\nwhich is associated with the hashes (especially if the certificate did not\r\npreviously exist in the TIE repository).\r\n\r\nIf the set reputation operation succeeds, the string \"Succeeded\" is written to\r\nthe `payload` property in the output message.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Set reputation in TIE` node. If the set reputation operation\r\nsucceeded, the text \"Succeeded\" should be displayed."
+        "info": "This sample invokes the TIE DXL service to set the enterprise-specific\r\n`trust level` of a certificate (as identified by hashes). The response to the\r\nTIE request is printed to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n* The DXL client associated with the `Set reputation in TIE` node must have\r\n  permission to send messages to the `/mcafee/service/tie/cert/reputation/set`\r\n  topic, which is part of the `TIE Server Set Enterprise Reputation`\r\n  authorization group.\r\n\r\n  The \r\n  [MAR client authorization documentation](https://opendxl.github.io/opendxl-client-python/pydoc/marsendauth.html)\r\n  provides an example of authorizing a DXL client to send messages to an\r\n  authorization group. While the example is based on McAfee Active Response\r\n  (MAR), the instructions are the same with the exception of swapping the\r\n  `TIE Server Set Enterprise Reputation` authorization group in place of\r\n  `Active Response Server API`.\r\n\r\n### Setup\r\n\r\n* Edit the `Set reputation request parameters` node and modify values of any of the\r\n  available properties, as desired. The only properties which are required are\r\n  `sha1` and `trustLevel`. The `publicKeySha1`, `trustLevel`, and/or `comment`\r\n  can also be specified through the web UI for the `Set reputation in TIE` node.\r\n  Note that if values are specified both on the flow message and the Web UI, the\r\n  value specified in the Web UI will be used. The available properties are:\r\n\r\n  * _sha1_ - SHA-1 of the certificate.\r\n  * _publicKeySha1_ - SHA-1 of the certificate's public key.\r\n  * _trustLevel_ - New \"trust level\" for the certificate. The numeric value\r\n    `99` indicates that the certificate is `Known Trusted`. The list of standard\r\n    \"trust levels\" can be found in the\r\n    [TrustLevel documentation](https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-TrustLevel.html)\r\n    in the TIE JavaScript client SDK.\r\n  * _comment_ - Comment to associate with the certificate. This value can be \r\n    empty but is useful in identifying the particular certificate\r\n    which is associated with the hashes (especially if the certificate did not\r\n    previously exist in the TIE repository).\r\n\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the\r\n  `Set reputation in TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Start flow` node.\r\n\r\n### Output\r\n\r\nIf the set reputation operation succeeds, the following message will be\r\ndisplayed:\r\n\r\n```\r\nSucceeded\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start flow\r\n\r\nThis is an `inject` input node which starts the flow.\r\n\r\n#### Set reputation request parameters\r\n\r\nThis is a `change` node which stores parameters used by the\r\n`Set reputation in TIE` node to the flow message. The available parameters\r\nare the `sha1` of the certificate, `publicKeySha1` of the certificate's\r\npublic key, `trustLevel` to be set for the certificate, and `comment` to\r\nassociate with the certificate.\r\n\r\n#### Set reputation in TIE\r\n\r\nThis is a `tie set certificate reputation` node. This node connects to\r\nthe DXL fabric and sends a DXL `Request` message to the TIE service to set\r\ncertificate reputation information.\r\n\r\nThe request message includes the request properties set by the\r\n`Set reputation request parameters` node.\r\n\r\nIf the set reputation operation succeeds, the string \"Succeeded\" is written to\r\nthe `payload` property in the output message.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Set reputation in TIE` node. If the set reputation operation\r\nsucceeded, the text \"Succeeded\" should be displayed."
     },
     {
-        "id": "40a36059.2152f",
+        "id": "657498c0.b8f968",
         "type": "dxl-tie-set-certificate-reputation",
-        "z": "d25ff850.471288",
+        "z": "43588515.3b92dc",
         "name": "Set reputation in TIE",
         "client": "",
-        "trustLevel": "99",
-        "comment": "Reputation set via OpenDXL",
-        "x": 320,
-        "y": 200,
+        "trustLevel": "",
+        "comment": "",
+        "x": 420,
+        "y": 220,
         "wires": [
             [
-                "27d72a8c.60fdc6"
+                "a608cf0e.47408"
             ]
         ]
     },
     {
-        "id": "27d72a8c.60fdc6",
+        "id": "a608cf0e.47408",
         "type": "debug",
-        "z": "d25ff850.471288",
+        "z": "43588515.3b92dc",
         "name": "Output result",
         "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
         "complete": "payload",
-        "x": 510,
-        "y": 200,
+        "x": 630,
+        "y": 220,
         "wires": []
     },
     {
-        "id": "60c244e6.02693c",
+        "id": "e1cb9d5a.2b72",
         "type": "inject",
-        "z": "d25ff850.471288",
-        "name": "Specify cert hashes",
+        "z": "43588515.3b92dc",
+        "name": "Start flow",
         "topic": "",
-        "payload": "{\"certBodySha1\":\"6eae26db8c13182a7947982991b4321732cc3de2\",\"publicKeySha1\":\"3b87a2d6f39770160364b79a152fcc73bae27adf\"}",
-        "payloadType": "json",
+        "payload": "",
+        "payloadType": "str",
         "repeat": "",
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 130,
+        "x": 100,
         "y": 40,
         "wires": [
             [
-                "dfa31b29.3666c8"
+                "5d077f47.5a21a"
             ]
         ]
     },
     {
-        "id": "dfa31b29.3666c8",
+        "id": "5d077f47.5a21a",
         "type": "change",
-        "z": "d25ff850.471288",
-        "name": "Set hash request parameters",
+        "z": "43588515.3b92dc",
+        "name": "Set reputation request parameters",
         "rules": [
             {
                 "t": "set",
                 "p": "sha1",
                 "pt": "msg",
-                "to": "payload.certBodySha1",
-                "tot": "msg"
+                "to": "6eae26db8c13182a7947982991b4321732cc3de2",
+                "tot": "str"
             },
             {
                 "t": "set",
                 "p": "publicKeySha1",
                 "pt": "msg",
-                "to": "payload.publicKeySha1",
-                "tot": "msg"
+                "to": "3b87a2d6f39770160364b79a152fcc73bae27adf",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "trustLevel",
+                "pt": "msg",
+                "to": "99",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "comment",
+                "pt": "msg",
+                "to": "Reputation set via OpenDXL",
+                "tot": "str"
             }
         ],
         "action": "",
@@ -82,22 +96,22 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 240,
-        "y": 120,
+        "x": 360,
+        "y": 122,
         "wires": [
             [
-                "40a36059.2152f"
+                "657498c0.b8f968"
             ]
         ]
     },
     {
-        "id": "acf6d288.0cdbc",
+        "id": "eac8ad7.6023d5",
         "type": "comment",
-        "z": "d25ff850.471288",
-        "name": "Supply the cert hashes in the 'Specify cert hashes' node",
+        "z": "43588515.3b92dc",
+        "name": "Supply the cert hashes, trustLevel, and comment in the 'Set reputation request parameters' node",
         "info": "",
-        "x": 460,
-        "y": 40,
+        "x": 550,
+        "y": 60,
         "wires": []
     }
 ]

--- a/examples/basic-set-file-reputation-example.json
+++ b/examples/basic-set-file-reputation-example.json
@@ -1,66 +1,66 @@
 [
     {
-        "id": "a5453627.48b848",
+        "id": "edb36936.4917b8",
         "type": "tab",
         "label": "TIE Set File Reputation Example",
         "disabled": false,
-        "info": "This sample invokes the TIE DXL service to set the enterprise-specific\r\n`trust level` of a file (as identified by hashes). The response to the\r\nTIE request is printed to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n* The DXL client associated with the `Set reputation in TIE` node must have permission to send messages to\r\n  the `/mcafee/service/tie/file/reputation/set` topic, which is part of the\r\n  `TIE Server Set Enterprise Reputation` authorization group.\r\n\r\n  The \r\n  [MAR client authorization documentation](https://opendxl.github.io/opendxl-client-python/pydoc/marsendauth.html)\r\n  provides an example of authorizing a DXL client to send messages to an\r\n  authorization group. While the example is based on McAfee Active Response\r\n  (MAR), the instructions are the same with the exception of swapping the\r\n  `TIE Server Set Enterprise Reputation` authorization group in place of\r\n  `Active Response Server API`.\r\n\r\n### Setup\r\n\r\n* Edit the `Specify file hashes` node and modify the `Payload` property with the\r\n  hashes of the file that you want to use for set operation.\r\n\r\n  The default hashes used in the JSON-formatted document for this node\r\n  pertain to `notepad.exe`:\r\n\r\n  ```json\r\n  {\r\n    \"md5\": \"f2c7bb8acc97f92e987a2d4087d021b1\",\r\n    \"sha1\": \"7eb0139d2175739b3ccb0d1110067820be6abd29\",\r\n    \"sha256\": \"142e1d688ef0568370c37187fd9f2351d7ddeda574f8bfa9b0fa4ef42db85aa2\"\r\n  }\r\n  ```\r\n\r\n* Edit the `Specify file name` node and modify the `Set` rule for the\r\n  `msg.fileName` property with the file name that you want to associate with\r\n  the hash values. The `fileName` property is optional, but is useful in\r\n  identifying the particular file that is associated with the hashes (especially\r\n  if the file did not previously exist in the TIE repository).\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the\r\n  `Set reputation in TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify file hashes` node.\r\n\r\n### Output\r\n\r\nIf the set reputation operation succeeds, the following message will be\r\ndisplayed:\r\n\r\n```\r\nSucceeded\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Specify file hashes\r\n\r\nThis is an `inject` input node which starts the flow. This node\r\ninjects a new message with a `payload` property which specifies the hashes of\r\nthe file to use for the set operation.\r\n\r\n#### Specify file name\r\n\r\nThis is a `change` node which sets the value of the `fileName` property on the\r\nmessage. The `Set reputation in TIE` node uses the `fileName` property when\r\nconstructing the parameters for the TIE file reputation request. \r\n\r\n#### Set hashes request parameter\r\n\r\nThis is a `change` node which copies the value from the `payload` message\r\nproperty to the `hashes` property. The `Set reputation in TIE` node uses the\r\n`hashes` property when constructing the parameters for the TIE file\r\nreputation request. \r\n\r\n#### Set reputation in TIE\r\n\r\nThis is a `tie set file reputation` node. This node connects to the DXL fabric\r\nand sends a DXL `Request` message to the TIE service to set file reputation\r\ninformation.\r\n\r\nThe request message includes the `hashes` property set by the\r\n`Set hash request parameters` node and the `fileName` property set by the\r\n`Specify file name` node.\r\n\r\nThe `Trust level` property is set to \"Known trusted\" and the\r\n`Comment` property is set to \"Reputation set via OpenDXL\". The `Comment`\r\nproperty can be empty but is useful in identifying the particular file which is\r\nassociated with the hashes (especially if the file did not previously exist in\r\nthe TIE repository).\r\n\r\nIf the set reputation operation succeeds, the string \"Succeeded\" is written to\r\nthe `payload` property in the output message.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Set reputation in TIE` node. If the set reputation operation\r\nsucceeded, the text \"Succeeded\" should be displayed."
+        "info": "This sample invokes the TIE DXL service to set the enterprise-specific\r\n`trust level` of a file (as identified by hashes). The response to the\r\nTIE request is printed to the Node-RED `debug` tab.\r\n\r\n### Prerequisites\r\n\r\n* The samples configuration step has been completed (see\r\n  [Client Configuration](https://opendxl.github.io/node-red-contrib-dxl/jsdoc/tutorial-configuration.html)).\r\n* A TIE service is available on the DXL fabric.\r\n* The DXL client associated with the `Set reputation in TIE` node must have permission to send messages to\r\n  the `/mcafee/service/tie/file/reputation/set` topic, which is part of the\r\n  `TIE Server Set Enterprise Reputation` authorization group.\r\n\r\n  The \r\n  [MAR client authorization documentation](https://opendxl.github.io/opendxl-client-python/pydoc/marsendauth.html)\r\n  provides an example of authorizing a DXL client to send messages to an\r\n  authorization group. While the example is based on McAfee Active Response\r\n  (MAR), the instructions are the same with the exception of swapping the\r\n  `TIE Server Set Enterprise Reputation` authorization group in place of\r\n  `Active Response Server API`.\r\n\r\n### Setup\r\n\r\n* Edit the `Set reputation request parameters` node and modify values of any of\r\n  the available properties, as desired. The only properties which are required\r\n  the `hashes` and `trustLevel`. The `fileName` and/or `comment` can also be\r\n  specified through the web UI for the `Set reputation in TIE` node. Note that\r\n  if values are specified both on the flow message and the Web UI, the value\r\n  specified in the Web UI will be used. The available properties are:\r\n\r\n  * _hashes.md5_, _hashes.sha1_, _hashes.sha256_ - Hashes of the file. The\r\n    default hashes used in the JSON-formatted document for this node pertain to\r\n    `notepad.exe`.\r\n  * _trustLevel_ - New \"trust level\" for the file. The numeric value `99` \r\n    indicates that the file is `Known Trusted`. The list of standard\r\n    \"trust levels\" can be found in the\r\n    [TrustLevel documentation](https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-TrustLevel.html)\r\n    in the TIE JavaScript client SDK.\r\n  * _fileName_ - Name to associate with the file.\r\n  * _comment_ - Comment to associate with the file. This value can be empty but\r\n    is useful in identifying the particular file which is associated with the\r\n    hashes (especially if the file did not previously exist in the TIE\r\n    repository).\r\n\r\n\r\n* To deploy the flow, press the `Deploy` button in the upper-right corner of the\r\n  screen. If Node-RED is able to properly connect to the DXL fabric, a green dot\r\n  with the word `connected` should appear under the\r\n  `Set reputation in TIE` node.\r\n\r\n### Running\r\n\r\nTo exercise the flow, double-click the button on the left side of the\r\n`Specify file hashes` node.\r\n\r\n### Output\r\n\r\nIf the set reputation operation succeeds, the following message will be\r\ndisplayed:\r\n\r\n```\r\nSucceeded\r\n```\r\n\r\n### Details\r\n\r\nThe flow exercises the nodes below.\r\n\r\n#### Start flow\r\n\r\nThis is an `inject` input node which starts the flow.\r\n\r\n#### Set reputation request parameter\r\n\r\nThis is a `change` node which stores parameters used by the\r\n`Set reputation in TIE` node to the flow message. The available parameters\r\nare the `hashes` of the file, `trustLevel` to be set for the file, `fileName`\r\nto associate with the file, and `comment` to associate with the file.\r\n\r\n#### Set reputation in TIE\r\n\r\nThis is a `tie set file reputation` node. This node connects to the DXL fabric\r\nand sends a DXL `Request` message to the TIE service to set file reputation\r\ninformation.\r\n\r\nThe request message includes the request properties set by the\r\n`Set reputation request parameters` node.\r\n\r\nIf the set reputation operation succeeds, the string \"Succeeded\" is written to\r\nthe `payload` property in the output message.\r\n\r\n#### Output result\r\n\r\nThis is a `debug` output node. This node outputs the `payload` set on\r\nthe message by the `Set reputation in TIE` node. If the set reputation operation\r\nsucceeded, the text \"Succeeded\" should be displayed."
     },
     {
-        "id": "b6d2814d.2847e",
+        "id": "d95c9c2c.6498d",
         "type": "dxl-tie-set-file-reputation",
-        "z": "a5453627.48b848",
+        "z": "edb36936.4917b8",
         "name": "Set reputation in TIE",
         "client": "",
-        "trustLevel": "99",
-        "comment": "Reputation set by OpenDXL",
-        "x": 380,
-        "y": 380,
+        "trustLevel": "",
+        "comment": "",
+        "x": 420,
+        "y": 220,
         "wires": [
             [
-                "585b8da3.da5ce4"
+                "bb360d14.52f57"
             ]
         ]
     },
     {
-        "id": "9eaacf13.ddcb6",
+        "id": "1ef8f0a1.9888ef",
         "type": "inject",
-        "z": "a5453627.48b848",
-        "name": "Specify file hashes",
+        "z": "edb36936.4917b8",
+        "name": "Start flow",
         "topic": "",
-        "payload": "{\"md5\":\"f2c7bb8acc97f92e987a2d4087d021b1\",\"sha1\":\"7eb0139d2175739b3ccb0d1110067820be6abd29\",\"sha256\":\"142e1d688ef0568370c37187fd9f2351d7ddeda574f8bfa9b0fa4ef42db85aa2\"}",
+        "payload": "{}",
         "payloadType": "json",
         "repeat": "",
         "crontab": "",
         "once": false,
         "onceDelay": 0.1,
-        "x": 130,
-        "y": 80,
+        "x": 100,
+        "y": 40,
         "wires": [
             [
-                "8d33bfe2.1c841"
+                "25e182e3.10cede"
             ]
         ]
     },
     {
-        "id": "585b8da3.da5ce4",
+        "id": "bb360d14.52f57",
         "type": "debug",
-        "z": "a5453627.48b848",
+        "z": "edb36936.4917b8",
         "name": "Output result",
         "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
         "complete": "payload",
-        "x": 570,
-        "y": 380,
+        "x": 630,
+        "y": 220,
         "wires": []
     },
     {
-        "id": "af7da3b4.3c35",
+        "id": "25e182e3.10cede",
         "type": "change",
-        "z": "a5453627.48b848",
-        "name": "Set hashes request parameter",
+        "z": "edb36936.4917b8",
+        "name": "Set reputation request parameters",
         "rules": [
             {
                 "t": "set",
@@ -68,52 +68,47 @@
                 "pt": "msg",
                 "to": "payload",
                 "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 310,
-        "y": 280,
-        "wires": [
-            [
-                "b6d2814d.2847e"
-            ]
-        ]
-    },
-    {
-        "id": "2f162b7e.930684",
-        "type": "comment",
-        "z": "a5453627.48b848",
-        "name": "Supply the file hashes in the 'Specify file hashes' node",
-        "info": "",
-        "x": 220,
-        "y": 40,
-        "wires": []
-    },
-    {
-        "id": "ffbb7631.662148",
-        "type": "comment",
-        "z": "a5453627.48b848",
-        "name": "Supply the file name in the 'Set file name' node",
-        "info": "",
-        "x": 420,
-        "y": 140,
-        "wires": []
-    },
-    {
-        "id": "8d33bfe2.1c841",
-        "type": "change",
-        "z": "a5453627.48b848",
-        "name": "Specify file name",
-        "rules": [
+            },
+            {
+                "t": "set",
+                "p": "hashes.md5",
+                "pt": "msg",
+                "to": "f2c7bb8acc97f92e987a2d4087d021b1",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "hashes.sha1",
+                "pt": "msg",
+                "to": "7eb0139d2175739b3ccb0d1110067820be6abd29",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "hashes.sha256",
+                "pt": "msg",
+                "to": "142e1d688ef0568370c37187fd9f2351d7ddeda574f8bfa9b0fa4ef42db85aa2",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "trustLevel",
+                "pt": "msg",
+                "to": "99",
+                "tot": "num"
+            },
             {
                 "t": "set",
                 "p": "fileName",
                 "pt": "msg",
                 "to": "notepad.exe",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "comment",
+                "pt": "msg",
+                "to": "Reputation set by OpenDXL",
                 "tot": "str"
             }
         ],
@@ -122,12 +117,22 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 230,
-        "y": 180,
+        "x": 360,
+        "y": 120,
         "wires": [
             [
-                "af7da3b4.3c35"
+                "d95c9c2c.6498d"
             ]
         ]
+    },
+    {
+        "id": "bf5b2ca2.6c3c7",
+        "type": "comment",
+        "z": "edb36936.4917b8",
+        "name": "Supply the file hashes, file name, trustLevel, and comment in the 'Set request parameters' node",
+        "info": "",
+        "x": 550,
+        "y": 60,
+        "wires": []
     }
 ]

--- a/nodes/dxl-tie-certificate-reputation-change-in.html
+++ b/nodes/dxl-tie-certificate-reputation-change-in.html
@@ -109,22 +109,22 @@
     },
     "updateTime": 1481219581
 }</pre>
-    <p>The top level property names in the object are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertRepChangeEventProp" target="_blank">CertRepChangeEventProp documentation</a> in the TIE Python client SDK.</p>
+    <p>The top level property names in the object are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertRepChangeEventProp.html" target="_blank">CertRepChangeEventProp documentation</a> in the TIE JavaScript client SDK.</p>
     <p>The reputation change information is separated into 4 distinct sections:</p>
     <h4>Hash Values</h4>
     <p>Keyed in the object by the <code>hashes</code> string.</p>
-    <p>An object of hashes that identify the certificate whose reputation has changed. The property in the object is the <code>hash type</code> and the <code>value</code> is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.HashType" target="_blank">HashType documentation</a> in the TIE Python client SDK for the list of hash type constants.</p>
+    <p>An object of hashes that identify the certificate whose reputation has changed. The property in the object is the <code>hash type</code> and the <code>value</code> is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-HashType.html" target="_blank">HashType documentation</a> in the TIE JavaScript client SDK for the list of hash type constants.</p>
     <p>There may also be a top-level property named <code>publicKeySha1</code> that contains the SHA-1 of the certificate's public key.</p>
     <h4>New Reputations</h4>
     <p>Keyed in the object by the <code>newReputations</code> string.</p>
     <p>The new reputations for the certificate whose reputation has changed, as an object.</p>
     <p>The property for each entry in the object corresponds to a particular
-    <code>provider</code> of the associated reputation. The list of certificate reputation providers can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertProvider" target="_blank">CertProvider documentation</a> in the TIE Python client SDK.</p>
-    <p>Each reputation contains a standard set of properties (trust level, creation date, etc.). These properties are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertReputationProp" target="_blank">CertReputationProp documentation</a> in the TIE Python client SDK.</p>
-    <p>Each reputation can also contain a provider-specific set of attributes, as an object. These attributes can be found in the TIE Python client SDK documentation:</p>
+    <code>provider</code> of the associated reputation. The list of certificate reputation providers can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertProvider.html" target="_blank">CertProvider documentation</a> in the TIE JavaScript client SDK.</p>
+    <p>Each reputation contains a standard set of properties (trust level, creation date, etc.). These properties are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertReputationProp.html" target="_blank">CertReputationProp documentation</a> in the TIE JavaScript client SDK.</p>
+    <p>Each reputation can also contain a provider-specific set of attributes, as an object. These attributes can be found in the TIE JavaScript client SDK documentation:</p>
     <ul>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertEnterpriseAttrib" target="_blank">CertEnterpriseAttrib</a> - Attributes associated with the <code>Enterprise</code> reputation provider for certificates</li>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertGtiAttrib" target="_blank">CertGtiAttrib</a> - Attributes associated with the <code>Global Threat Intelligence (GTI)</code> reputation provider for certificates</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertEnterpriseAttrib.html" target="_blank">CertEnterpriseAttrib</a> - Attributes associated with the <code>Enterprise</code> reputation provider for certificates</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertGtiAttrib.html" target="_blank">CertGtiAttrib</a> - Attributes associated with the <code>Global Threat Intelligence (GTI)</code> reputation provider for certificates</li>
     </ul>
     <h4>Old Reputations</h4>
     <p>Keyed in the object by the <code>oldReputations</code> string.</p>

--- a/nodes/dxl-tie-file-detection-in.html
+++ b/nodes/dxl-tie-file-detection-in.html
@@ -69,7 +69,7 @@
     "name": "TEST_MALWARE.EXE",
     "remediationAction": 5
 }</pre>
-    <p>The top level property names in the object are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.DetectionEventProp" target="_blank">DetectionEventProp documentation</a> in the TIE Python client SDK.</p>
+    <p>The top level property names in the object are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-DetectionEventProp.html" target="_blank">DetectionEventProp documentation</a> in the TIE JavaScript client SDK.</p>
     <p>The information provided in the object includes:</p>
     <ul>
         <li>System the detection occurred on</li>

--- a/nodes/dxl-tie-file-first-instance-in.html
+++ b/nodes/dxl-tie-file-first-instance-in.html
@@ -66,7 +66,7 @@
     },
     "name": "MORPH.EXE"
 }</pre>
-    <p>The top level property names in the object are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FirstInstanceEventProp" target="_blank">FirstInstanceEventProp documentation</a> in the TIE Python client SDK.</p>
+    <p>The top level property names in the object are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FirstInstanceEventProp.html" target="_blank">FirstInstanceEventProp documentation</a> in the TIE JavaScript client SDK.</p>
     <p>The information provided in the object includes:</p>
     <ul>
         <li>System the first instance of the file was found on</li>

--- a/nodes/dxl-tie-file-reputation-change-in.html
+++ b/nodes/dxl-tie-file-reputation-change-in.html
@@ -109,22 +109,22 @@
     },
     "updateTime": 1481219581
 }</pre>
-    <p>The top level property names in the object are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileRepChangeEventProp" target="_blank">FileRepChangeEventProp documentation</a> in the TIE Python client SDK.</p>
+    <p>The top level property names in the object are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileRepChangeEventProp.html" target="_blank">FileRepChangeEventProp documentation</a> in the TIE JavaScript client SDK.</p>
     <p>The reputation change information is separated into 4 distinct sections:</p>
     <h4>Hash Values</h4>
     <p>Keyed in the object by the <code>hashes</code> string.</p>
-    <p>An object of hashes that identify the file whose reputation has changed. The property in the object is the <code>hash type</code> and the <code>value</code> is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.HashType" target="_blank">HashType documentation</a> in the TIE Python client SDK for the list of hash type constants.</p>
+    <p>An object of hashes that identify the file whose reputation has changed. The property in the object is the <code>hash type</code> and the <code>value</code> is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-HashType.html" target="_blank">HashType documentation</a> in the TIE JavaScript client SDK for the list of hash type constants.</p>
     <h4>New Reputations</h4>
     <p>Keyed in the object by the <code>newReputations</code> string.</p>
     <p>The new reputations for the file whose reputation has changed, as an object.</p>
     <p>The property for each entry in the object corresponds to a particular
-    <code>provider</code> of the associated reputation. The list of file reputation providers can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileProvider" target="_blank">FileProvider documentation</a> in the TIE Python client SDK.</p>
-    <p>Each reputation contains a standard set of properties (trust level, creation date, etc.). These properties are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileReputationProp" target="_blank">FileReputationProp documentation</a> in the TIE Python client SDK.</p>
-    <p>Each reputation can also contain a provider-specific set of attributes, as an object. These attributes can be found in the TIE Python client SDK documentation:</p>
+    <code>provider</code> of the associated reputation. The list of file reputation providers can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileProvider.html" target="_blank">FileProvider documentation</a> in the TIE JavaScript client SDK.</p>
+    <p>Each reputation contains a standard set of properties (trust level, creation date, etc.). These properties are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileReputationProp.html" target="_blank">FileReputationProp documentation</a> in the TIE JavaScript client SDK.</p>
+    <p>Each reputation can also contain a provider-specific set of attributes, as an object. These attributes can be found in the TIE JavaScript client SDK documentation:</p>
     <ul>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileEnterpriseAttrib" target="_blank">FileEnterpriseAttrib</a> - Attributes associated with the <code>Enterprise</code> reputation provider for files</li>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileGtiAttrib" target="_blank">FileGtiAttrib</a> - Attributes associated with the <code>Global Threat Intelligence (GTI)</code> reputation provider for files</li>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.AtdAttrib" target="_blank">AtdAttrib</a> - Attributes associated with the <code>Advanced Threat Defense (ATD)</code> reputation provider</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileEnterpriseAttrib.html" target="_blank">FileEnterpriseAttrib</a> - Attributes associated with the <code>Enterprise</code> reputation provider for files</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileGtiAttrib.html" target="_blank">FileGtiAttrib</a> - Attributes associated with the <code>Global Threat Intelligence (GTI)</code> reputation provider for files</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-AtdAttrib.html" target="_blank">AtdAttrib</a> - Attributes associated with the <code>Advanced Threat Defense (ATD)</code> reputation provider</li>
     </ul>
     <h4>Old Reputations</h4>
     <p>Keyed in the object by the <code>oldReputations</code> string.</p>

--- a/nodes/dxl-tie-get-certificate-first-references.html
+++ b/nodes/dxl-tie-get-certificate-first-references.html
@@ -50,7 +50,7 @@
     <dl class="message-properties">
         <dt>sha1 <span class="property-type">string</span></dt>
         <dd> SHA-1 of the certificate.</dd>
-        <dt class="optional">publicKeySha1 <span class="property-type">number</span></dt>
+        <dt class="optional">publicKeySha1 <span class="property-type">string</span></dt>
         <dd> SHA-1 of the certificate's public key.</dd>
         <dt class="optional">queryLimit <span class="property-type">number</span></dt>
         <dd> Maximum number of results to return.</dd>
@@ -85,5 +85,5 @@
         "date": 1478626172
     }
 ]</pre>
-    <p>See the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FirstRefProp" target="_blank">FirstRefProp documentation</a> in the TIE Python client SDK for details about the information that is available for each system in the object.</p>
+    <p>See the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FirstRefProp.html" target="_blank">FirstRefProp documentation</a> in the TIE JavaScript client SDK for details about the information that is available for each system in the object.</p>
 </script>

--- a/nodes/dxl-tie-get-certificate-reputation.html
+++ b/nodes/dxl-tie-get-certificate-reputation.html
@@ -45,14 +45,14 @@
     <dl class="message-properties">
         <dt>sha1 <span class="property-type">string</span></dt>
         <dd> The SHA-1 of the certificate.</dd>
-        <dt class="optional">publicKeySha1 <span class="property-type">number</span></dt>
+        <dt class="optional">publicKeySha1 <span class="property-type">string</span></dt>
         <dd> The SHA-1 of the certificate's public key.</dd>
     </dl>
     <h3>Outputs</h3>
     <dl class="message-properties">
         <dt>payload <span class="property-type">string | object | buffer</span></dt>
         <dd> Object where each <code>value</code> is a reputation from a particular reputation provider which is identified by the <code>key</code>.
-        The list of certificate reputation providers can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertProvider" target="_blank">CertProvider documentation</a> in the TIE Python client SDK.
+        The list of certificate reputation providers can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertProvider.html" target="_blank">CertProvider documentation</a> in the TIE JavaScript client SDK.
         Through the <code>Return</code> node property, the node can be configured to set the payload type as a UTF-8 String, an Object parsed from a JSON formatted string, or as a binary Buffer.</dd>
     </dl>
     <p>The <code>sha1</code> and <code>publicKeySha1</code> properties are removed, if present, from the output message.</p>
@@ -92,10 +92,10 @@
     }
 }</pre>
     <p>The <code>2</code> key corresponds to a reputation from the "Global Threat Intelligence (GTI)" reputation provider while the <code>4</code> key corresponds to a reputation from the "Enterprise" reputation provider.
-    <p>Each reputation contains a standard set of properties (trust level, creation date, etc.). These properties are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertReputationProp" target="_blank">CertReputationProp documentation</a> in the TIE Python client SDK.</p>
-    <p>Each reputation can also contain a provider-specific set of attributes, as an object. These attributes can be found in the TIE Python client SDK documentation:</p>
+    <p>Each reputation contains a standard set of properties (trust level, creation date, etc.). These properties are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertReputationProp.html" target="_blank">CertReputationProp documentation</a> in the TIE JavaScript client SDK.</p>
+    <p>Each reputation can also contain a provider-specific set of attributes, as an object. These attributes can be found in the TIE JavaScript client SDK documentation:</p>
     <ul>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertEnterpriseAttrib" target="_blank">CertEnterpriseAttrib</a> - Attributes associated with the <code>Enterprise</code> reputation provider for certificates</li>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.CertGtiAttrib" target="_blank">CertGtiAttrib</a> - Attributes associated with the <code>Global Threat Intelligence (GTI)</code> reputation provider for certificates</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertEnterpriseAttrib.html" target="_blank">CertEnterpriseAttrib</a> - Attributes associated with the <code>Enterprise</code> reputation provider for certificates</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-CertGtiAttrib.html" target="_blank">CertGtiAttrib</a> - Attributes associated with the <code>Global Threat Intelligence (GTI)</code> reputation provider for certificates</li>
     </ul>
 </script>

--- a/nodes/dxl-tie-get-file-first-references.html
+++ b/nodes/dxl-tie-get-file-first-references.html
@@ -50,7 +50,7 @@
     <h3>Inputs</h3>
     <dl class="message-properties">
         <dt>hashes <span class="property-type">object</span></dt>
-        <dd> Object of hashes that identify the file to lookup. Each property name in the object is the <code>hash type</code> and the associated value is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.HashType" target="_blank">HashType documentation</a> in the TIE Python client SDK for the list of hash type constants.</dd>
+        <dd> Object of hashes that identify the file to lookup. Each property name in the object is the <code>hash type</code> and the associated value is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-HashType.html" target="_blank">HashType documentation</a> in the TIE JavaScript client SDK for the list of hash type constants.</dd>
         <dt class="optional">queryLimit <span class="property-type">number</span></dt>
         <dd> Maximum number of results to return.</dd>
     </dl>
@@ -84,5 +84,5 @@
         "date": 1478626172
     }
 ]</pre>
-    <p>See the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FirstRefProp" target="_blank">FirstRefProp documentation</a> in the TIE Python client SDK for details about the information that is available for each system in the object.</p>
+    <p>See the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FirstRefProp.html" target="_blank">FirstRefProp documentation</a> in the TIE JavaScript client SDK for details about the information that is available for each system in the object.</p>
 </script>

--- a/nodes/dxl-tie-get-file-reputation.html
+++ b/nodes/dxl-tie-get-file-reputation.html
@@ -44,13 +44,13 @@
     <h3>Inputs</h3>
     <dl class="message-properties">
         <dt>hashes <span class="property-type">object</span></dt>
-        <dd> Object of hashes that identify the file to lookup. Each property name in the object is the <code>hash type</code> and the associated value is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.HashType" target="_blank">HashType documentation</a> in the TIE Python client SDK for the list of hash type constants.</dd>
+        <dd> Object of hashes that identify the file to lookup. Each property name in the object is the <code>hash type</code> and the associated value is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-HashType.html" target="_blank">HashType documentation</a> in the TIE JavaScript client SDK for the list of hash type constants.</dd>
     </dl>
     <h3>Outputs</h3>
     <dl class="message-properties">
         <dt>payload <span class="property-type">string | object | buffer</span></dt>
         <dd> Object where each <code>value</code> is a reputation from a particular reputation provider which is identified by the <code>key</code>.
-        The list of file reputation providers can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileProvider" target="_blank">FileProvider documentation</a> in the TIE Python client SDK.
+        The list of file reputation providers can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileProvider.html" target="_blank">FileProvider documentation</a> in the TIE JavaScript client SDK.
         Through the <code>Return</code> node property, the node can be configured to set the payload type as a UTF-8 String, an Object parsed from a JSON formatted string, or as a binary Buffer.</dd>
     </dl>
     <p>The <code>hashes</code> properties is removed, if present, from the output message.</p>
@@ -88,11 +88,11 @@
     }
 }</pre>
     <p>The <code>1</code> key corresponds to a reputation from the "Global Threat Intelligence (GTI)" reputation provider while the <code>3</code> key corresponds to a reputation from the "Enterprise" reputation provider.
-    <p>Each reputation contains a standard set of properties (trust level, creation date, etc.). These properties are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileReputationProp" target="_blank">FileReputationProp documentation</a> in the TIE Python client SDK.</p>
-    <p>Each reputation can also contain a provider-specific set of attributes, as an object. These attributes can be found in the TIE Python client SDK documentation:</p>
+    <p>Each reputation contains a standard set of properties (trust level, creation date, etc.). These properties are listed in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileReputationProp.html" target="_blank">FileReputationProp documentation</a> in the TIE JavaScript client SDK.</p>
+    <p>Each reputation can also contain a provider-specific set of attributes, as an object. These attributes can be found in the TIE JavaScript client SDK documentation:</p>
     <ul>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileEnterpriseAttrib" target="_blank">FileEnterpriseAttrib</a> - Attributes associated with the <code>Enterprise</code> reputation provider for files</li>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.FileGtiAttrib" target="_blank">FileGtiAttrib</a> - Attributes associated with the <code>Global Threat Intelligence (GTI)</code> reputation provider for files</li>
-        <li><a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.AtdAttrib" target="_blank">AtdAttrib</a> - Attributes associated with the <code>Advanced Threat Defense (ATD)</code> reputation provider</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileEnterpriseAttrib.html" target="_blank">FileEnterpriseAttrib</a> - Attributes associated with the <code>Enterprise</code> reputation provider for files</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-FileGtiAttrib.html" target="_blank">FileGtiAttrib</a> - Attributes associated with the <code>Global Threat Intelligence (GTI)</code> reputation provider for files</li>
+        <li><a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-AtdAttrib.html" target="_blank">AtdAttrib</a> - Attributes associated with the <code>Advanced Threat Defense (ATD)</code> reputation provider</li>
     </ul>
 </script>

--- a/nodes/dxl-tie-set-certificate-reputation.html
+++ b/nodes/dxl-tie-set-certificate-reputation.html
@@ -58,10 +58,10 @@
     <dl class="message-properties">
         <dt>sha1 <span class="property-type">string</span></dt>
         <dd> SHA-1 of the certificate.</dd>
-        <dt class="optional">publicKeySha1 <span class="property-type">number</span></dt>
+        <dt class="optional">publicKeySha1 <span class="property-type">string</span></dt>
         <dd> SHA-1 of the certificate's public key.</dd>
         <dt class="optional">trustLevel <span class="property-type">number</span></dt>
-        <dd> New "trust level" for the certificate. The list of standard "trust levels" can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.TrustLevel" target="_blank">TrustLevel documentation</a> in the TIE Python client SDK.</dd>
+        <dd> New "trust level" for the certificate. The list of standard "trust levels" can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-TrustLevel.html" target="_blank">TrustLevel documentation</a> in the TIE JavaScript client SDK.</dd>
         <dt class="optional">comment <span class="property-type">string</span></dt>
         <dd> Comment to associate with the certificate.</dd>
     </dl>

--- a/nodes/dxl-tie-set-file-reputation.html
+++ b/nodes/dxl-tie-set-file-reputation.html
@@ -57,9 +57,9 @@
     <h3>Inputs</h3>
     <dl class="message-properties">
         <dt>hashes <span class="property-type">object</span></dt>
-        <dd> Object of hashes that identify the file to lookup. Each property name in the object is the <code>hash type</code> and the associated value is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.HashType" target="_blank">HashType documentation</a> in the TIE Python client SDK for the list of hash type constants.</dd>
+        <dd> Object of hashes that identify the file to lookup. Each property name in the object is the <code>hash type</code> and the associated value is the hex representation of the hash value. See the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-HashType.html" target="_blank">HashType documentation</a> in the TIE JavaScript client SDK for the list of hash type constants.</dd>
         <dt class="optional">trustLevel <span class="property-type">number</span></dt>
-        <dd> New "trust level" for the file. The list of standard "trust levels" can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-python/pydoc/dxltieclient.constants.html#dxltieclient.constants.TrustLevel" target="_blank">TrustLevel documentation</a> in the TIE Python client SDK.</dd>
+        <dd> New "trust level" for the file. The list of standard "trust levels" can be found in the <a href="https://opendxl.github.io/opendxl-tie-client-javascript/jsdoc/module-TrustLevel.html" target="_blank">TrustLevel documentation</a> in the TIE JavaScript client SDK.</dd>
         <dt class="optional">fileName<span class="property-type">string</span></dt>
         <dd> Name to associate with the file.</dd>
         <dt class="optional">comment <span class="property-type">string</span></dt>


### PR DESCRIPTION
Previously, the parameters used in TIE requests in the examples could be
set across multiple nodes within the flow - the starting inject node, a
change node, and/or the request node itself. In this commit, the
examples have been updated to uniformly set all of the available TIE
request parameters from within the change node which immediately
precedes the TIE request node in the flow.

This commit also updates links to the TIE client documentation to
reference the JavaScript SDK doc pages instead of the Python SDK doc
pages and fixes cases where the type of the `publicKeySha1` property was
listed as `number` to instead be the correct type, `string`.